### PR TITLE
improve arguments style

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 While [`axlsx`](https://github.com/randym/axlsx) is an excellent tool to build Excel spreadsheets in Ruby, the sheets styles are only applied immediately as the row is created. This makes it very difficult to style easily and effectively.
 
-To solve this issue, `axlsx_styler` was born to allow the separatation of styles from content within your `axlsx` code. It gives you the ability to fill out a spreadsheet with data and apply styles later. 
+To solve this issue, `axlsx_styler` was born to allow the separation of styles from content within your `axlsx` code. It gives you the ability to fill out a spreadsheet with data and apply styles later. 
 
 Works well in any Rails app or outside of any specific Ruby framework.
 


### PR DESCRIPTION
Thank you for making nice gem :smile: 
I always use caxlsx with axlsx-styler.

I often apply the same style with multiple cells below.
```
['K6:Q7', 'K10:Q11', 'K14:Q15'].each do |cell_range|
  sheet.add_style cell_range, bg_color: 'E2E9F9'
end
```

But, I want to use `add_style` like this.
```
sheet.add_style ['K6:Q7', 'K10:Q11', 'K14:Q15'], bg_color: 'E2E9F9'
```

So, I fixed source codes a little.

I am happy if you could merge it :pray: 
