### PR TITLE
Dont overwrite the font defaults if they have been customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+- **Unreleased**
+  - [#](https://github.com/axlsx-styler-gem/axlsx_styler/pull/) - Do not overwrite spreadsheet default font attributes if they have been overriden 
+
 - **1.1.0 - August 26, 2020**
   - [Issue #29](https://github.com/axlsx-styler-gem/axlsx_styler/issues/29) - Fix error `Invalid cellXfs id` when applying `dxf` styles
   - [PR #28](https://github.com/axlsx-styler-gem/axlsx_styler/pull/28) - Allow passing arrays of cell ranges to the `add_style` and `add_border` methods
+
 - **1.0.0 - January 5, 2020**
   - Switch to the `caxlsx` gem (Community Axlsx) from the legacy unmaintained `axlsx` gem. Axlsx has had a long history of being poorly maintained so this community gem improves the situation.
   - Require Ruby 2.3+
@@ -10,14 +14,19 @@
   - Removed unnecessary module `AxlsxStyler::Axlsx`
   - Major test suite improvements
   - Add Rails dummy app to test suite and test with `axlsx_rails`
+
 - **0.2.0**
   - Add support for `axlsx` v3 (at this time for v3.0.0.pre).
   - Update test suite to run against both v2 and v3 of `axlsx`
+
 - **0.1.7**
   - Allow mixing vanilla `axlsx` styles and those from `add_style` and `add_border`. See [this example](./examples/mixing_styles.rb)
+
 - **0.1.5**
   - Hide `Workbook#apply_styles` method to make it easier to use.
+
 - **0.1.3**
   - Make border styles customizable.
+
 - **0.1.2**
   - Allow applying multiple style hashes.

--- a/lib/axlsx_styler/axlsx_styles.rb
+++ b/lib/axlsx_styler/axlsx_styles.rb
@@ -12,7 +12,10 @@ module AxlsxStyler
       if options[:type] == :dxf
         style_id = super
       else
-        raw_style = {type: :xf, name: 'Arial', sz: 11, family: 1}.merge(options)
+        ### https://github.com/caxlsx/caxlsx/blob/9b6a78f43b9415bd155bddf6a6d872f5d5555595/lib/axlsx/stylesheet/styles.rb#L459
+        font_defaults = {name: @fonts.first.name, sz: @fonts.first.sz, family: @fonts.first.family} 
+
+        raw_style = {type: :xf}.merge(font_defaults).merge(options)
 
         if raw_style[:format_code]
           raw_style.delete(:num_fmt)


### PR DESCRIPTION
Solves #34 

Will now respect any customization to the following built-in axlsx font defaults

```ruby
workbook.styles.fonts[0].name = "Arial"
workbook.styles.fonts[0].sz = 11
workbook.styles.fonts[0].family = 1
```